### PR TITLE
Let az and za arrays have an arbitrary number of axes

### DIFF
--- a/mwa_pb/mwa_tile.py
+++ b/mwa_pb/mwa_tile.py
@@ -459,10 +459,10 @@ def makeUnpolInstrumentalResponse(j1, j2):
     """
     result = numpy.empty_like(j1)
 
-    result[:, :, 0, 0] = j1[:, :, 0, 0] * j2[:, :, 0, 0].conjugate() + j1[:, :, 0, 1] * j2[:, :, 0, 1].conjugate()
-    result[:, :, 1, 1] = j1[:, :, 1, 0] * j2[:, :, 1, 0].conjugate() + j1[:, :, 1, 1] * j2[:, :, 1, 1].conjugate()
-    result[:, :, 0, 1] = j1[:, :, 0, 0] * j2[:, :, 1, 0].conjugate() + j1[:, :, 0, 1] * j2[:, :, 1, 1].conjugate()
-    result[:, :, 1, 0] = j1[:, :, 1, 0] * j2[:, :, 0, 0].conjugate() + j1[:, :, 1, 1] * j2[:, :, 0, 1].conjugate()
+    result[..., 0, 0] = j1[..., 0, 0] * j2[..., 0, 0].conjugate() + j1[..., 0, 1] * j2[..., 0, 1].conjugate()
+    result[..., 1, 1] = j1[..., 1, 0] * j2[..., 1, 0].conjugate() + j1[..., 1, 1] * j2[..., 1, 1].conjugate()
+    result[..., 0, 1] = j1[..., 0, 0] * j2[..., 1, 0].conjugate() + j1[..., 0, 1] * j2[..., 1, 1].conjugate()
+    result[..., 1, 0] = j1[..., 1, 0] * j2[..., 0, 0].conjugate() + j1[..., 1, 1] * j2[..., 0, 1].conjugate()
     return result
 
 
@@ -558,6 +558,8 @@ def plotVisResponse(j, freq, za):
     """
     import matplotlib.pyplot as plt
 
+    if not len(j.shape) == 4:
+        raise ValueError, "plotVisResponse expects a matrix of dimensions [za][az][2][2]"
     vis = makeUnpolInstrumentalResponse(j, j)
     plt.imshow(numpy.abs(vis[:, :, 0, 0]))
     plt.title('MWA ' + str(freq / 1e6) + 'MHz XX mag ZA=' + str(za))

--- a/mwa_pb/primary_beam.py
+++ b/mwa_pb/primary_beam.py
@@ -59,12 +59,7 @@ def MWA_Tile_full_EE(za, az, freq,
 
     # Use swapaxis to place jones matrices in last 2 dimensions
     # insead of first 2 dims.
-    if len(j.shape) == 4:
-        j = numpy.swapaxes(numpy.swapaxes(j, 0, 2), 1, 3)
-    elif len(j.shape) == 3:  # 1-D
-        j = numpy.swapaxes(numpy.swapaxes(j, 1, 2), 0, 1)
-    else:  # single value
-        pass
+    j = numpy.swapaxes(numpy.swapaxes(j, 0, -2), 1, -1)
 
     if jones:
         return j
@@ -72,9 +67,9 @@ def MWA_Tile_full_EE(za, az, freq,
     # Use mwa_tile makeUnpolInstrumentalResponse because we have swapped axes
     vis = mwa_tile.makeUnpolInstrumentalResponse(j, j)
     if not power:
-        return (numpy.sqrt(vis[:, :, 0, 0].real), numpy.sqrt(vis[:, :, 1, 1].real))
+        return (numpy.sqrt(vis[..., 0, 0].real), numpy.sqrt(vis[..., 1, 1].real))
     else:
-        return (vis[:, :, 0, 0].real, vis[:, :, 1, 1].real)
+        return (vis[..., 0, 0].real, vis[..., 1, 1].real)
 
 
 #########


### PR DESCRIPTION
This is a modest change to mwa_pb. At present, the zenith angle and azimuth arrays must have two dimensions (i.e. assuming that you want to make a primary beam image). Often you just want the primary beam for a list of locations. The following generalise the code so that an arbitrary number of dimensions can be used. I've located one function that will fail with this change (plotVisResponse) and made sure that it fails with a proper error.

I've tested this code for some basic use cases without any issues.

Before merging, can someone please double-check my first change to primary_beam.py (the swapaxes on) I think it's equivalent to the two cases it replaces, but it would be good for someone to double-check.