### PR TITLE
Pip installable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*h5 filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.xml
 *.pyc
-*.h5
 .idea
 build
 dist

--- a/mwa_pb/data/mwa_full_embedded_element_pattern.h5
+++ b/mwa_pb/data/mwa_full_embedded_element_pattern.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7649c6e03b8128a1de4614c2f363af5fa44f3890ae27bf893d56ca337bc48ee
+size 133209592

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,25 @@
 from setuptools import setup
+from subprocess import check_output
+
+#The following two functions were taken from the repo: https://github.com/pyfidelity/setuptools-git-version/blob/master/setuptools_git_version.py
+def format_version(version, fmt='{tag}.{commitcount}'):
+    parts = version.split('-')
+    if len(parts) == 1:
+        return parts[0]
+    assert len(parts) in (3, 4)
+    dirty = len(parts) == 4
+    tag, count, sha = parts[:3]
+    if count == '0' and not dirty:
+        return tag
+    return fmt.format(tag=tag, commitcount=count)
+
+def get_git_version():
+    git_version = check_output('git describe --tags --long --dirty --always'.split()).decode('utf-8').strip()
+    return format_version(version=git_version)
 
 setup(
     name='mwa_pb',
-    version='1.1.0',
+    version=get_git_version(),
     packages=['mwa_pb'],
     package_data={'mwa_pb':['data/*.fits', 'data/*.txt', 'data/*.h5', 'data/*.fab', 'data/*.dat']},
     url='https://github.com/MWATelescope/mwa_pb',
@@ -18,6 +35,6 @@ setup(
              'scripts/plot_skymap.py',
              'scripts/primarybeammap_tant_test.py',
              'scripts/track_and_suppress.py'],
-    install_requires=["numpy", "astropy", "skyfield", "matplotlib", "scipy>=0.15.1", "h5py"],
+    install_requires=["numpy", "astropy", "skyfield>=1.16", "matplotlib", "scipy>=0.15.1", "h5py"],
     extras_require={'skymap':["ephem", "Pillow"]}   # Needed only to generate sky maps in mwa_pb/skymap.py
 )


### PR DESCRIPTION
Used git lfs to add the .h5 file so we no longer need a wget command in installation. 
Added a function in setup.py to update the third digit of the version number. For example if you release this as v1.0 and there are three commits since then it will be version v1.0.3. This should make it easier to keep updated versions of the code on PyPi as you can make a version for each pull request.

This should be enough to make the repo pip installable, I even gave it a go myself with TestPyPi. You can test it using: 
` pip install -i https://test.pypi.org/simple/ mwa-pb`