### PR TITLE
Add deprecation notice and fix numpy dtype issue

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,3 +1,10 @@
+*********************************************************************************
+*** NOTE: mwa_pb is officially unsupported and we will not be maintaining it. ***
+*********************************************************************************
+For the vast majority of cases, users to should migrate to using hyperdrive for
+any and all primary beam modelling requirements.
+
+
 
 MWA Telescope Primary Beam code
 

--- a/mwa_pb/beam_full_EE.py
+++ b/mwa_pb/beam_full_EE.py
@@ -136,7 +136,7 @@ class ApertureArray(object):
         proj of ph onto N-S is max when ph_EtN=0 (ph_NtE=90)"""
 
         mybeam = Beam(self, delays=np.zeros([2, 16]), amps=np.ones([2, 16]))
-        self.norm_fac = np.zeros((2, 2), dtype=np.complex128)
+        self.norm_fac = np.zeros((2, 2), dtype=complex)
 
         # fill in Jones matrix
         # 2017-05-31 : MS changed normalisation at zenith to ABS so that normalisation does not change signs of the Jones matrix
@@ -314,8 +314,8 @@ class Beam(object):
 
             # accumulating spherical harmonics coefficients for the array
             # initialize
-            Q1_accum = np.zeros(max_length, dtype=np.complex128)
-            Q2_accum = np.zeros(max_length, dtype=np.complex128)
+            Q1_accum = np.zeros(max_length, dtype=complex)
+            Q2_accum = np.zeros(max_length, dtype=complex)
 
             # Read in modes
             try:
@@ -327,8 +327,8 @@ class Beam(object):
             N_accum = None
             for ant_i in range(n_ant):
                 # re-initialise Q1 and Q2 for every antenna
-                Q1 = np.zeros(max_length, dtype=np.complex128)
-                Q2 = np.zeros(max_length, dtype=np.complex128)
+                Q1 = np.zeros(max_length, dtype=complex)
+                Q2 = np.zeros(max_length, dtype=complex)
 
                 # select spherical wave table
                 name = '%s%s_%s' % (pols[pol], ant_i + 1, self.AA.freq)
@@ -461,7 +461,7 @@ class Beam(object):
 
         logger.debug('Calculating a gridded beam and interpolating onto coordinates of shape %s...' % (phi_arr.shape,))
         # Interpolate from gridded beam
-        Jones = np.zeros((2, 2) + np.shape(phi_arr), dtype=np.complex128)
+        Jones = np.zeros((2, 2) + np.shape(phi_arr), dtype=complex)
 
         logger.debug('Calculating gridded beam (Az=0-360, ZA=0-90) at angular resolution %s pixels per degree... %s' %
                      (pixels_per_deg, datetime.datetime.now().time()))
@@ -514,14 +514,14 @@ class Beam(object):
                 e = 'For gridded beam, theta (shape %s) and phi (shape %s) must be 1-D arrays'
                 logger.error(e % (np.shape(theta_arr), np.shape(phi_arr)))
                 raise ValueError(e % (np.shape(theta_arr), np.shape(phi_arr)))
-            Jones = np.zeros((2, 2, len(phi_arr), len(theta_arr)), dtype=np.complex128)
+            Jones = np.zeros((2, 2, len(phi_arr), len(theta_arr)), dtype=complex)
         else:
             # Create Jones matrix of shape: 2 x 2 x shape(phi_arr)
             if phi_arr.shape != theta_arr.shape:
                 e = 'Theta (shape %s) and phi (shape %s) must be the same shape'
                 logger.error(e % (np.shape(theta_arr), np.shape(phi_arr)))
                 raise ValueError(e % (np.shape(theta_arr), np.shape(phi_arr)))
-            Jones = np.zeros((2, 2) + np.shape(phi_arr), dtype=np.complex128)
+            Jones = np.zeros((2, 2) + np.shape(phi_arr), dtype=complex)
 
         counter = 10000  # Counter for messages
 
@@ -588,8 +588,8 @@ class Beam(object):
             # really fine grids (dimension reduces from [nmax^2+2*nmax] to [2*nmax+1] )
             # tests showed that the overhead for summing and re-calculating phi
             # is smaller than doing the dot product without reductions (especially for fine grids)
-            emn_P_sum = np.zeros((len(theta_unique), 2 * nmax + 1), dtype=np.complex128)
-            emn_T_sum = np.zeros((len(theta_unique), 2 * nmax + 1), dtype=np.complex128)
+            emn_P_sum = np.zeros((len(theta_unique), 2 * nmax + 1), dtype=complex)
+            emn_T_sum = np.zeros((len(theta_unique), 2 * nmax + 1), dtype=complex)
             for m in range(-nmax, nmax + 1):
                 emn_P_sum[:, m + nmax] = np.sum(emn_P[:, M == m], axis=1)
                 emn_T_sum[:, m + nmax] = np.sum(emn_T[:, M == m], axis=1)
@@ -673,7 +673,7 @@ def P1sin_array(nmax, theta):
         Pm1 = np.vstack([P[1::, :], np.zeros((1, np.size(theta)))])  # I should just be able to use orders=np.arange(1,n+1), then append zero?
         # Pm1=Pm1.reshape(len(Pm1),1)   # FIXME: can probably make this and others 1-D
         # P_{n}^{|m|}(u)/sin_th
-        # Pm_sin=np.zeros((n+1,1),dtype=np.complex128) #initialize
+        # Pm_sin=np.zeros((n+1,1),dtype=complex) #initialize
         # parameters
         Pm_sin = P / sin_theta
         # accumulate Psin and P1 for the m values

--- a/mwa_pb/mwa_impedance.py
+++ b/mwa_pb/mwa_impedance.py
@@ -138,7 +138,7 @@ class LNAImpedance(object):
                               15.243 - 81.042j, 15.146 - 80.671j, 15.05 - 80.296j, 14.973 - 79.911j,
                               14.955 - 79.614j, 14.876 - 79.266j, 14.839 - 78.892j, 14.723 - 78.569j,
                               14.683 - 78.282j, 14.643 - 78.058j, 14.614 - 77.894j, 14.594 - 77.713j],
-                             dtype=numpy.complex)
+                             dtype=complex)
 
     def getZ(self, freq):
         """Return the interpolated LNA impedance (Ohms) for the freq (Hz)
@@ -164,7 +164,7 @@ class TileImpedanceMatrix(object):
         except IOError:
             raise Exception('Cannot load impedance file %s' % filename)
         nfreqs = len(hdus)
-        self.Zmatrix = numpy.empty((nfreqs,) + (32, 32), dtype=numpy.complex64)
+        self.Zmatrix = numpy.empty((nfreqs,) + (32, 32), dtype=complex)
         self.freqs = numpy.zeros(nfreqs)
         for i in range(nfreqs):
             mag = hdus[i].data[0, ...]
@@ -173,7 +173,7 @@ class TileImpedanceMatrix(object):
             self.freqs[i] = hdus[i].header['FREQ']
         #        freqs_MHz=[88,119,155,186,216]
         #        self.freqs = numpy.array(freqs_MHz,dtype=numpy.float32)*1e6
-        #        self.Zmatrix = numpy.empty(self.freqs.shape + (32,32),dtype=numpy.complex)
+        #        self.Zmatrix = numpy.empty(self.freqs.shape + (32,32),dtype=complex)
         #        freqind=0
         #        for f in freqs_MHz:
         #            realfile = filesdir+"ZReal"+str(f)+"MHz.txt"

--- a/mwa_pb/mwa_tile.py
+++ b/mwa_pb/mwa_tile.py
@@ -63,7 +63,7 @@ class Dipole(object):
         self.height = height
         self.length = length
         if gain is None:
-            self.gain = numpy.eye(2, dtype=numpy.complex64)
+            self.gain = numpy.eye(2, dtype=complex)
         else:
             self.gain = gain
         self.interp_freq = 0.0
@@ -94,7 +94,7 @@ class Dipole(object):
         # p = numpy.where
         nza = len(self.lookup_za)
         nph = len(self.lookup_ph)
-        self.lookup = numpy.empty((nfreqs, nza, nph, 2, 2), dtype=numpy.complex64)
+        self.lookup = numpy.empty((nfreqs, nza, nph, 2, 2), dtype=complex)
         freqs = []
         for i in range(nfreqs):
             hdu = hdulist[i]
@@ -195,7 +195,7 @@ class Dipole(object):
         j11 = self.i11_real.ev(za_deg.flatten(), ph_deg.flatten()) + 1.0j * self.i11_imag.ev(za_deg.flatten(),
                                                                                              ph_deg.flatten())
 
-        result = numpy.empty((za.shape + (2, 2)), dtype=numpy.complex64)
+        result = numpy.empty((za.shape + (2, 2)), dtype=complex)
         result[..., 0, 0] = j00.reshape(za.shape) / self.j00norm
         result[..., 0, 1] = -j01.reshape(za.shape) / self.j01norm  # sign flip between az and phi
         result[..., 1, 0] = j10.reshape(za.shape) / self.j10norm
@@ -218,7 +218,7 @@ class Dipole(object):
         assert az.shape == za.shape, "Input za and az arrays must have same dimension"
 
         # output array has 2x2 Jones matrix for every az/za point in input
-        result = numpy.empty((za.shape + (2, 2)), dtype=numpy.complex64)
+        result = numpy.empty((za.shape + (2, 2)), dtype=complex)
         # apply the groundscreen factor, which is independent of az
         # znorm = 1.0
         gs = self.groundScreen(za, freq)
@@ -314,8 +314,8 @@ class ApertureArray(object):
         sz = numpy.sin(za)
         kx = (2.0 * numpy.pi / lam) * numpy.sin(az) * sz
         ky = (2.0 * numpy.pi / lam) * numpy.cos(az) * sz
-        ax = numpy.zeros_like(az, dtype=numpy.complex64)
-        ay = numpy.zeros_like(az, dtype=numpy.complex64)
+        ax = numpy.zeros_like(az, dtype=complex)
+        ay = numpy.zeros_like(az, dtype=complex)
         for i in range(len(self.xpos)):
             ph = kx * self.xpos[i] + ky * self.ypos[i]
             ax += port_current[1, i] * (numpy.cos(ph) + 1.0j * numpy.sin(ph))  # X dipoles

--- a/scripts/mwa_sensitivity.py
+++ b/scripts/mwa_sensitivity.py
@@ -108,7 +108,7 @@ def calculate_sensitivity(freq, delays, gps, trcv_type, T_rcv, size, dirname, mo
 #            T_rcv = trcv_from_skymodel_with_err(freq_mhz)
 #            print("T_rcv calculated from trcv_from_skymodel_with_err = %.2f K" % (T_rcv))
     T_rcv = trcv_daniel_paper_2020( freq_mhz )
-    print "T_rcv calculated from trcv_daniel_paper_2020( %.2f MHz ) = %.2f K" % (freq_mhz,T_rcv)
+    print("T_rcv calculated from trcv_daniel_paper_2020( %.2f MHz ) = %.2f K" % (freq_mhz,T_rcv))
 
     result = make_primarybeammap(gps, delays, freq,
                                  model=model,

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(
              'scripts/plot_skymap.py',
              'scripts/primarybeammap_tant_test.py',
              'scripts/track_and_suppress.py'],
-    install_requires=["numpy>=1.20", "astropy", "skyfield>=1.16", "matplotlib", "scipy>=0.15.1", "h5py"],
+    install_requires=["numpy>=1.18", "astropy", "skyfield>=1.16", "matplotlib", "scipy>=0.15.1", "h5py"],
     extras_require={'skymap':["ephem", "Pillow"]}   # Needed only to generate sky maps in mwa_pb/skymap.py
 )

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
              'scripts/plot_skymap.py',
              'scripts/primarybeammap_tant_test.py',
              'scripts/track_and_suppress.py'],
-    install_requires=["numpy", "astropy", "skyfield>=1.16", "matplotlib", "scipy>=0.15.1", "h5py"],
+    install_requires=["numpy>=1.20", "astropy", "skyfield>=1.16", "matplotlib", "scipy>=0.15.1", "h5py"],
     extras_require={'skymap':["ephem", "Pillow"]}   # Needed only to generate sky maps in mwa_pb/skymap.py
 )

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@ import os
 from setuptools import setup
 from subprocess import check_output
 
+print(" **  THIS PACKAGE IS OFFICIALLY UNSUPPORTED  ** ")
+print("Use at your own risk...\n\n")
 
 # Download the mwa_full_embedded_element_pattern.h5 file if it doesn't exist
 datadir = os.path.join(os.path.dirname(__file__), 'mwa_pb', 'data')
@@ -21,13 +23,13 @@ if not os.path.exists(h5file):
 
 setup(
     name='mwa_pb',
-    version='1.4',
+    version='1.4.1',
     packages=['mwa_pb'],
     package_data={'mwa_pb':['data/*.fits', 'data/*.txt', 'data/*.h5', 'data/*.fab', 'data/*.dat']},
     url='https://github.com/MWATelescope/mwa_pb',
     license='GPLv3',
-    author='MWA Team members, repo managed by Andrew Williams',
-    author_email='Andrew.Williams@curtin.edu.au',
+    author='MWA Team members',
+    author_email='',
     description='MWA Primary beam code',
     scripts=['scripts/beam_correct_image.py',
              'scripts/beamtest.py',


### PR DESCRIPTION
This is essentially to make `mwa_pb` with modern `numpy` versions, but to also officially note it's deprecation.

`mwa_pb` is no longer actively maintained, and this change is likely going to be the last. While it may still be used, YMMV. 